### PR TITLE
[IHOST-1544] Fix nginx integration crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.2 (date TBD)
+## Next Release (date TBD)
 ### Fixed
 - Issue where if nginx status page response code was different than 200
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 (date TBD)
+### Fixed
+- Issue where if nginx status page response code was different than 200
+
 ## 1.0.1 (2018-09-07)
 ### Changed
 - Update Makefile

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -165,9 +165,8 @@ func getMetricsData(sample *metric.MetricSet) error {
 	if err != nil {
 		return err
 	}
-	// If is not a successful status code 2xx.
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("failed to get stats from nginx. Server returned code %d (%s). Expecting 2xx",
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get stats from nginx. Server returned code %d (%s). Expecting 200",
 			resp.StatusCode, resp.Status)
 	}
 	defer resp.Body.Close()

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -165,6 +165,11 @@ func getMetricsData(sample *metric.MetricSet) error {
 	if err != nil {
 		return err
 	}
+	// If is not a successful status code 2xx.
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("failed to get stats from nginx. Server returned code %d (%s). Expecting 2xx",
+			resp.StatusCode, resp.Status)
+	}
 	defer resp.Body.Close()
 	var rawMetrics map[string]interface{}
 	var metricsDefinition map[string][]interface{}


### PR DESCRIPTION
#### Description of the changes

If the nginx status page was unavailable, then the integration crashed.
In Go a non-2xx status code doesn't cause an error so additional status code check was added.

https://newrelic.atlassian.net/browse/IHOST-1544

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
