### PR TITLE
Add support for ngx_http_api_module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ bin/
 coverage.xml
 target/
 bin
+tmp/
+go.mod
+go.sum
 # Vim swap
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ See [metrics]() or [inventory]() for more details about collected data and revie
 
 ## Configuration
 * Depending on which NGINX edition you use please update your configuration enabling
-  * [HTTP stub status module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) for NGINX Open Source
-  * [HTTP status module](http://nginx.org/en/docs/http/ngx_http_status_module.html) for NGINX Plus
+  * [ngx_http_stub_status_module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) for NGINX Open Source
+  * [ngx_http_status_module](http://nginx.org/en/docs/http/ngx_http_status_module.html) for NGINX Plus pre 1.13.3
+  * [ngx_http_api_module](http://nginx.org/en/docs/http/ngx_http_api_module.html) for NGINX 1.13.3 and higher
+  
+### ngx_http_api_module configuration
+Additions to the `nginx-config.yaml` file:
+* status_url: full path to the status url _including_ the api version. For example `http://localhost/api/4`
+* status_module: `ngx_http_api_module`
+* endpoints: list of `api/4`, NON PARAMETERIZED, endpoints to query
+  * Default:"/nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync" 
 
 ## Installation
 * download an archive file for the NGINX Integration

--- a/nginx-config.yml.sample
+++ b/nginx-config.yml.sample
@@ -4,7 +4,14 @@ instances:
     - name: nginx-server-metrics
       command: metrics
       arguments:
+          # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
           status_url: http://127.0.0.1/status
+	      # Name of Nginx status module OHI is query against. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
+	      status_module: ngx_http_stub_status_module
+
+	      # ngx_http_api_module ONLY
+          # Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints
+          # endpoints: /nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync
 
           # New users should leave this property as `true`, to identify the
           # monitored entities as `remote`. Setting this property to `false` (the

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"io"
 	"net/http"
 	"regexp"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jeremywohl/flatten"
+	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
@@ -157,7 +158,120 @@ func populateMetrics(sample *metric.Set, metrics map[string]interface{}, metrics
 	return nil
 }
 
-func getMetricsData(sample *metric.Set) error {
+func getMetricsData(sample *metric.Set) (err error) {
+	switch args.StatusModule {
+	case httpStubStatus:
+		resp, err := getStatus("")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		metricsDefinition := metricsStandardDefinition
+		rawMetrics, err := getStandardMetrics(bufio.NewReader(resp.Body))
+		rawVersion := strings.Replace(resp.Header.Get("Server"), "nginx/", "", -1)
+		rawMetrics["version"] = rawVersion
+
+		if err != nil {
+			return err
+		}
+		return populateMetrics(sample, rawMetrics, metricsDefinition)
+
+	case httpStatus:
+		resp, err := getStatus("")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		metricsDefinition := metricsPlusDefinition
+		rawMetrics, err := getPlusMetrics(bufio.NewReader(resp.Body))
+
+		if err != nil {
+			return err
+		}
+		return populateMetrics(sample, rawMetrics, metricsDefinition)
+
+	case httpApiStatus:
+		for _, p := range strings.Split(args.Endpoints, ",") {
+			resp, err := getStatus(p)
+			if err != nil {
+				fmt.Printf("%+v\n", err)
+				continue
+			}
+			getHttpApiMetrics(p, sample, bufio.NewReader(resp.Body))
+			resp.Body.Close()
+		}
+	}
+	return
+}
+
+// No tests for this. All we'd be testing is that Decode and Flatten work.
+func getHttpApiMetrics(path string, sample *metric.Set, reader *bufio.Reader) {
+	jsonMetrics := make(map[string]interface{})
+	dec := json.NewDecoder(reader)
+	err := dec.Decode(&jsonMetrics)
+	if err != nil {
+		return
+	}
+	if jsonMetrics == nil || len(jsonMetrics) <= 0 {
+		return
+	}
+
+	flat, err := flatten.Flatten(jsonMetrics, "", flatten.DotStyle)
+	if err != nil {
+		log.Error("Error flattening json: %+v", err)
+		return
+	}
+
+	for k, v := range flat {
+		sample.SetMetric(pathToPrefix(path)+k, v, getAttributeType(v))
+	}
+}
+
+var notJustDots = regexp.MustCompile(`[^.]`)
+
+func pathToPrefix(path string) (prefix string) {
+	prefix = strings.TrimPrefix(path, "/")
+	prefix = strings.ReplaceAll(prefix, "/", ".")
+	if !strings.HasSuffix(prefix, ".") {
+		prefix = prefix + "."
+	}
+	if prefix == "." {
+		prefix = ""
+	}
+	if !notJustDots.MatchString(prefix) {
+		prefix = ""
+	}
+	return prefix
+}
+
+// The v4 API only has Gauges & Attributes, no Rates
+func getAttributeType(v interface{}) metric.SourceType {
+	switch v.(type) {
+	case string:
+		return metric.ATTRIBUTE
+	default:
+		return metric.GAUGE
+	}
+
+}
+
+func getStatus(path string) (resp *http.Response, err error) {
+	netClient := &http.Client{
+		Timeout: time.Second * 1,
+	}
+	resp, err = netClient.Get(args.StatusURL + path)
+	if err != nil {
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, fmt.Errorf("failed to get stats from %s. Server returned code %d (%s). Expecting 200", args.StatusURL+path, resp.StatusCode, resp.Status)
+	}
+	return
+}
+
+func getMetricsData2(sample *metric.Set) error {
 	netClient := &http.Client{
 		Timeout: time.Second * 1,
 	}

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -119,3 +119,32 @@ func TestGetStandardMetricsWithInvalidData(t *testing.T) {
 		t.Error()
 	}
 }
+
+func Test_pathToPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		prefix string
+	}{
+		{"Single", "nginx", "nginx."},
+		{"Single, prefix", "/nginx", "nginx."},
+		{"Single, suffix", "nginx/", "nginx."},
+		{"Single,  bracketed", "/nginx/", "nginx."},
+		{"Multi", "nginx/version", "nginx.version."},
+		{"Multi, prefix", "/nginx/version", "nginx.version."},
+		{"Multi, suffix", "nginx/version/", "nginx.version."},
+		{"Multi, bracketed", "/nginx/version/", "nginx.version."},
+		{"Empty", "", ""},
+		{"Single slash", "/", ""},
+		{"Double slash", "//", ""},
+		{"Triple slash", "///", ""},
+		{"Quad slash", "////", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotPrefix := pathToPrefix(tt.path); gotPrefix != tt.prefix {
+				t.Errorf("pathToPrefix() = %v, want %v", gotPrefix, tt.prefix)
+			}
+		})
+	}
+}

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -14,9 +14,12 @@ import (
 
 type argumentList struct {
 	sdk_args.DefaultArgumentList
-	StatusURL        string `default:"http://127.0.0.1/status" help:"NGINX status URL."`
-	ConfigPath       string `default:"/etc/nginx/nginx.conf" help:"NGINX configuration file."`
-	RemoteMonitoring bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
+	StatusURL         string `default:"http://127.0.0.1/status" help:"NGINX status URL. If you are using ngx_http_api_module be sure to include the full path ending with the API version number"`
+	ConfigPath        string `default:"/etc/nginx/nginx.conf" help:"NGINX configuration file."`
+	RemoteMonitoring  bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
+	ConnectionTimeout int    `default:"1" help:"OHI connection to Nginx timeout in seconds"`
+	StatusModule      string `default:"ngx_http_stub_status_module" help:"Name of Nginx status module. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module"`
+	Endpoints         string `default:"/nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync" help:"Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints"`
 }
 
 const (
@@ -29,6 +32,11 @@ const (
 	httpProtocol     = `http`
 	httpDefaultPort  = `80`
 	httpsDefaultPort = `443`
+
+	apiv4          = "/api/4"
+	httpStubStatus = "ngx_http_stub_status_module"
+	httpStatus     = "ngx_http_status_module"
+	httpApiStatus  = "ngx_http_api_module"
 )
 
 var (


### PR DESCRIPTION
Added support for ngx_http_api_module.

This  includes some refactoring of metrics.go and additional config params.