### PR TITLE
Add support for ngx_http_api_module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ bin/
 coverage.xml
 target/
 bin
+tmp/
+go.mod
+go.sum
 # Vim swap
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.11"
+- "1.9"
 
 services:
 - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for `ngx_http_api_module`.
 - New configuration options:
     - `connection_timeout`: timeout (in seconds) for the connection from the integration to Nginx
-    - `status_module` (default: `discover`). Aaccepted values:
+    - `status_module` (default: `discover`). Accepted values:
         * `ngx_http_stub_status_module`
         * `ngx_http_status_module`
         * `ngx_http_api_module`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 (to be released)
+### Added
+- Support for `ngx_http_api_module`.
+- New configuration options:
+    - `connection_timeout`: timeout (in seconds) for the connection from the integration to Nginx
+    - `status_module` (default: `discover`). Aaccepted values:
+        * `ngx_http_stub_status_module`
+        * `ngx_http_status_module`
+        * `ngx_http_api_module`
+        * `discover` to automatically choose between `ngx_http_stub_status_module` or `ngx_http_status_module`.
+    - `endpoints`: if `status_module` is `ngx_http_api_module`, comma separated list, NON PARAMETERIZED, Endpoints   
+
 ## 1.2.0 (2019-04-29)
 ### Added
 - Upgraded to SDK v3.1.5. This version implements [the aget/integrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.9 as builder
 RUN go get -d github.com/newrelic/nri-nginx/... && \
     cd /go/src/github.com/newrelic/nri-nginx && \
     make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9 as builder
+FROM golang:1.12 as builder
 RUN go get -d github.com/newrelic/nri-nginx/... && \
     cd /go/src/github.com/newrelic/nri-nginx && \
     make && \

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ See [metrics]() or [inventory]() for more details about collected data and revie
 
 ## Configuration
 * Depending on which NGINX edition you use please update your configuration enabling
-  * [HTTP stub status module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) for NGINX Open Source
-  * [HTTP status module](http://nginx.org/en/docs/http/ngx_http_status_module.html) for NGINX Plus
+  * [ngx_http_stub_status_module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) for NGINX Open Source
+  * [ngx_http_status_module](http://nginx.org/en/docs/http/ngx_http_status_module.html) for NGINX Plus pre 1.13.3
+  * [ngx_http_api_module](http://nginx.org/en/docs/http/ngx_http_api_module.html) for NGINX 1.13.3 and higher
+  
+### ngx_http_api_module configuration
+Additions to the `nginx-config.yaml` file:
+* status_url: full path to the status url _including_ the api version. For example `http://localhost/api/4`
+* status_module: `ngx_http_api_module`
+* endpoints: list of `api/4`, NON PARAMETERIZED, endpoints to query
+  * Default:"/nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync" 
 
 ## Installation
 * download an archive file for the NGINX Integration

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,12 +8,17 @@ In the event that a required notice is missing or incorrect, please notify us
 by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 
 For any licenses that require the disclosure of source code, the source code
-can be found at github.com/newrelic/nri-nginx.
+can be found at {project_url}.
 
 ## Contents
  
-* [Sirupsen/logrus](#Sirupsenlogrus)
+* [pkg/errors](#pkgerrors)
+* [jeremywohl/flatten](#jeremywohlflatten)
+* [xeipuuv/gojsonschema](#xeipuuvgojsonschema)
 * [newrelic/infra-integrations-sdk](#newrelicinfra-integrations-sdk)
+* [xeipuuv/gojsonpointer](#xeipuuvgojsonpointer)
+* [xeipuuv/gojsonreference](#xeipuuvgojsonreference)
+* [stretchr/testify](#stretchrtestify)
 
 ## newrelic/infra-integrations-sdk
 
@@ -71,15 +76,439 @@ punitive damages or for lost profits or data.
 ```
 
 
-## Sirupsen/logrus
+## xeipuuv/gojsonpointer
 
-* Web: github.com/Sirupsen/logrus
+* Web: github.com/xeipuuv/gojsonpointer
+* License: Apache-2.0
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+
+## xeipuuv/gojsonreference
+
+* Web: github.com/xeipuuv/gojsonreference
+* License: Apache-2.0
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+
+## stretchr/testify
+
+* Web: github.com/stretchr/testify
 * License: MIT
 
 ```
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Simon Eskildsen
+Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -88,16 +517,292 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+
+## pkg/errors
+
+* Web: github.com/pkg/errors
+* License: BSD-2-Clause
+
+```
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
+
+## jeremywohl/flatten
+
+* Web: github.com/jeremywohl/flatten
+* License: MIT
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2016 Jeremy Wohl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+
+## xeipuuv/gojsonschema
+
+* Web: github.com/xeipuuv/gojsonschema
+* License: Apache-2.0
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 ```
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,69 +12,13 @@ can be found at {project_url}.
 
 ## Contents
  
-* [pkg/errors](#pkgerrors)
+* [stretchr/testify](#stretchrtestify)
+* [xeipuuv/gojsonreference](#xeipuuvgojsonreference)
 * [jeremywohl/flatten](#jeremywohlflatten)
+* [pkg/errors](#pkgerrors)
+* [xeipuuv/gojsonpointer](#xeipuuvgojsonpointer)
 * [xeipuuv/gojsonschema](#xeipuuvgojsonschema)
 * [newrelic/infra-integrations-sdk](#newrelicinfra-integrations-sdk)
-* [xeipuuv/gojsonpointer](#xeipuuvgojsonpointer)
-* [xeipuuv/gojsonreference](#xeipuuvgojsonreference)
-* [stretchr/testify](#stretchrtestify)
-
-## newrelic/infra-integrations-sdk
-
-* Web: github.com/newrelic/infra-integrations-sdk
-* License: Unknown
-
-```
-All components of this product are Copyright (c) 2017 New Relic, Inc.  All
-rights reserved.
-
-Certain inventions disclosed in this file may be claimed within patents owned or
-patent applications filed by New Relic, Inc. or third parties.
-
-Subject to the terms of this notice, New Relic grants you a nonexclusive,
-nontransferable license, without the right to sublicense, to (a) install and
-execute one copy of these files on any number of workstations owned or
-controlled by you and (b) distribute verbatim copies of these files to third
-parties.  You may install, execute, and distribute these files and their
-contents only in conjunction with your direct use of New Relic’s services.
-These files and their contents shall not be used with or to develop any other
-product or software that may compete with any New Relic product, feature, or
-software. As a condition to the foregoing grant, you must provide this notice
-along with each copy you distribute and you must not remove, alter, or obscure
-this notice.  In the event you submit or provide any feedback, code, pull
-requests, or suggestions to New Relic you hereby grant New Relic a worldwide,
-non-exclusive, irrevocable, transferable, fully paid-up license to use the code,
-algorithms, patents, and ideas therein in our products.  In addition to the
-rights above, New Relic grants a limited right to you to modify this product as
-necessary to enable interoperability with other systems, provided that (a) such
-use is solely to enable your direct use of New Relic services and (b) you agree
-to make any such modifications available to New Relic in a pull request or as
-separate feedback.
-
-All other use, reproduction, modification, distribution, or other exploitation
-of these files is strictly prohibited, except as may be set forth in a separate
-written license agreement between you and New Relic.  The terms of any such
-license agreement will control over this notice.  The license stated above will
-be automatically terminated and revoked if you exceed its scope or violate any
-of the terms of this notice.
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of New Relic, except as required for reasonable
-and customary use in describing the origin of this file and reproducing the
-content of this notice.  You may not mark or brand this file with any trade
-name, trademarks, service marks, or product names other than the original brand
-(if any) provided by New Relic.
-
-Unless otherwise expressly agreed by New Relic in a separate written license
-agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND,
-including without any implied warranties of MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
-these files, you are solely responsible for such use. New Relic will have no
-liability to you for direct, indirect, consequential, incidental, special, or
-punitive damages or for lost profits or data.
-```
-
 
 ## xeipuuv/gojsonpointer
 
@@ -284,6 +228,305 @@ punitive damages or for lost profits or data.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+```
+
+
+## xeipuuv/gojsonschema
+
+* Web: github.com/xeipuuv/gojsonschema
+* License: Apache-2.0
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
+
+## newrelic/infra-integrations-sdk
+
+* Web: github.com/newrelic/infra-integrations-sdk
+* License: Unknown
+
+```
+All components of this product are Copyright (c) 2017 New Relic, Inc.  All
+rights reserved.
+
+Certain inventions disclosed in this file may be claimed within patents owned or
+patent applications filed by New Relic, Inc. or third parties.
+
+Subject to the terms of this notice, New Relic grants you a nonexclusive,
+nontransferable license, without the right to sublicense, to (a) install and
+execute one copy of these files on any number of workstations owned or
+controlled by you and (b) distribute verbatim copies of these files to third
+parties.  You may install, execute, and distribute these files and their
+contents only in conjunction with your direct use of New Relic’s services.
+These files and their contents shall not be used with or to develop any other
+product or software that may compete with any New Relic product, feature, or
+software. As a condition to the foregoing grant, you must provide this notice
+along with each copy you distribute and you must not remove, alter, or obscure
+this notice.  In the event you submit or provide any feedback, code, pull
+requests, or suggestions to New Relic you hereby grant New Relic a worldwide,
+non-exclusive, irrevocable, transferable, fully paid-up license to use the code,
+algorithms, patents, and ideas therein in our products.  In addition to the
+rights above, New Relic grants a limited right to you to modify this product as
+necessary to enable interoperability with other systems, provided that (a) such
+use is solely to enable your direct use of New Relic services and (b) you agree
+to make any such modifications available to New Relic in a pull request or as
+separate feedback.
+
+All other use, reproduction, modification, distribution, or other exploitation
+of these files is strictly prohibited, except as may be set forth in a separate
+written license agreement between you and New Relic.  The terms of any such
+license agreement will control over this notice.  The license stated above will
+be automatically terminated and revoked if you exceed its scope or violate any
+of the terms of this notice.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of New Relic, except as required for reasonable
+and customary use in describing the origin of this file and reproducing the
+content of this notice.  You may not mark or brand this file with any trade
+name, trademarks, service marks, or product names other than the original brand
+(if any) provided by New Relic.
+
+Unless otherwise expressly agreed by New Relic in a separate written license
+agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND,
+including without any implied warranties of MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
+these files, you are solely responsible for such use. New Relic will have no
+liability to you for direct, indirect, consequential, incidental, special, or
+punitive damages or for lost profits or data.
+```
+
+
+## stretchr/testify
+
+* Web: github.com/stretchr/testify
+* License: MIT
+
+```
+MIT License
+
+Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ```
 
@@ -500,15 +743,15 @@ punitive damages or for lost profits or data.
 ```
 
 
-## stretchr/testify
+## jeremywohl/flatten
 
-* Web: github.com/stretchr/testify
+* Web: github.com/jeremywohl/flatten
 * License: MIT
 
 ```
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
+Copyright (c) 2016 Jeremy Wohl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -560,249 +803,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-```
-
-
-## jeremywohl/flatten
-
-* Web: github.com/jeremywohl/flatten
-* License: MIT
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2016 Jeremy Wohl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
-
-
-## xeipuuv/gojsonschema
-
-* Web: github.com/xeipuuv/gojsonschema
-* License: Apache-2.0
-
-```
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2015 xeipuuv
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 
 ```
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,7 +8,7 @@ In the event that a required notice is missing or incorrect, please notify us
 by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 
 For any licenses that require the disclosure of source code, the source code
-can be found at {project_url}.
+can be found at http://github.com/newrelic/nri-nginx.
 
 ## Contents
  

--- a/nginx-config.yml.sample
+++ b/nginx-config.yml.sample
@@ -4,7 +4,14 @@ instances:
     - name: nginx-server-metrics
       command: metrics
       arguments:
+          # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
           status_url: http://127.0.0.1/status
+	      # Name of Nginx status module OHI is query against. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
+	      status_module: ngx_http_stub_status_module
+
+	      # ngx_http_api_module ONLY
+          # Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints
+          # endpoints: /nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync
 
           # New users should leave this property as `true`, to identify the
           # monitored entities as `remote`. Setting this property to `false` (the

--- a/nginx-config.yml.sample
+++ b/nginx-config.yml.sample
@@ -6,8 +6,8 @@ instances:
       arguments:
           # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
           status_url: http://127.0.0.1/status
-	      # Name of Nginx status module OHI is query against. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-	      status_module: ngx_http_stub_status_module
+	      # Name of Nginx status module OHI is to query against. discovery | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
+	      status_module: discovery
 
 	      # ngx_http_api_module ONLY
           # Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"io"
 	"net/http"
 	"regexp"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jeremywohl/flatten"
+	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
@@ -157,7 +158,120 @@ func populateMetrics(sample *metric.Set, metrics map[string]interface{}, metrics
 	return nil
 }
 
-func getMetricsData(sample *metric.Set) error {
+func getMetricsData(sample *metric.Set) (err error) {
+	switch args.StatusModule {
+	case httpStubStatus:
+		resp, err := getStatus("")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		metricsDefinition := metricsStandardDefinition
+		rawMetrics, err := getStandardMetrics(bufio.NewReader(resp.Body))
+		rawVersion := strings.Replace(resp.Header.Get("Server"), "nginx/", "", -1)
+		rawMetrics["version"] = rawVersion
+
+		if err != nil {
+			return err
+		}
+		return populateMetrics(sample, rawMetrics, metricsDefinition)
+
+	case httpStatus:
+		resp, err := getStatus("")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		metricsDefinition := metricsPlusDefinition
+		rawMetrics, err := getPlusMetrics(bufio.NewReader(resp.Body))
+
+		if err != nil {
+			return err
+		}
+		return populateMetrics(sample, rawMetrics, metricsDefinition)
+
+	case httpApiStatus:
+		for _, p := range strings.Split(args.Endpoints, ",") {
+			resp, err := getStatus(p)
+			if err != nil {
+				fmt.Printf("%+v\n", err)
+				continue
+			}
+			getHttpApiMetrics(p, sample, bufio.NewReader(resp.Body))
+			resp.Body.Close()
+		}
+	}
+	return
+}
+
+// No tests for this. All we'd be testing is that Decode and Flatten work.
+func getHttpApiMetrics(path string, sample *metric.Set, reader *bufio.Reader) {
+	jsonMetrics := make(map[string]interface{})
+	dec := json.NewDecoder(reader)
+	err := dec.Decode(&jsonMetrics)
+	if err != nil {
+		return
+	}
+	if jsonMetrics == nil || len(jsonMetrics) <= 0 {
+		return
+	}
+
+	flat, err := flatten.Flatten(jsonMetrics, "", flatten.DotStyle)
+	if err != nil {
+		log.Error("Error flattening json: %+v", err)
+		return
+	}
+
+	for k, v := range flat {
+		sample.SetMetric(pathToPrefix(path)+k, v, getAttributeType(v))
+	}
+}
+
+var notJustDots = regexp.MustCompile(`[^.]`)
+
+func pathToPrefix(path string) (prefix string) {
+	prefix = strings.TrimPrefix(path, "/")
+	prefix = strings.ReplaceAll(prefix, "/", ".")
+	if !strings.HasSuffix(prefix, ".") {
+		prefix = prefix + "."
+	}
+	if prefix == "." {
+		prefix = ""
+	}
+	if !notJustDots.MatchString(prefix) {
+		prefix = ""
+	}
+	return prefix
+}
+
+// The v4 API only has Gauges & Attributes, no Rates
+func getAttributeType(v interface{}) metric.SourceType {
+	switch v.(type) {
+	case string:
+		return metric.ATTRIBUTE
+	default:
+		return metric.GAUGE
+	}
+
+}
+
+func getStatus(path string) (resp *http.Response, err error) {
+	netClient := &http.Client{
+		Timeout: time.Second * 1,
+	}
+	resp, err = netClient.Get(args.StatusURL + path)
+	if err != nil {
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, fmt.Errorf("failed to get stats from %s. Server returned code %d (%s). Expecting 200", args.StatusURL+path, resp.StatusCode, resp.Status)
+	}
+	return
+}
+
+func getMetricsData2(sample *metric.Set) error {
 	netClient := &http.Client{
 		Timeout: time.Second * 1,
 	}

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -119,3 +119,32 @@ func TestGetStandardMetricsWithInvalidData(t *testing.T) {
 		t.Error()
 	}
 }
+
+func Test_pathToPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		prefix string
+	}{
+		{"Single", "nginx", "nginx."},
+		{"Single, prefix", "/nginx", "nginx."},
+		{"Single, suffix", "nginx/", "nginx."},
+		{"Single,  bracketed", "/nginx/", "nginx."},
+		{"Multi", "nginx/version", "nginx.version."},
+		{"Multi, prefix", "/nginx/version", "nginx.version."},
+		{"Multi, suffix", "nginx/version/", "nginx.version."},
+		{"Multi, bracketed", "/nginx/version/", "nginx.version."},
+		{"Empty", "", ""},
+		{"Single slash", "/", ""},
+		{"Double slash", "//", ""},
+		{"Triple slash", "///", ""},
+		{"Quad slash", "////", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotPrefix := pathToPrefix(tt.path); gotPrefix != tt.prefix {
+				t.Errorf("pathToPrefix() = %v, want %v", gotPrefix, tt.prefix)
+			}
+		})
+	}
+}

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -24,7 +24,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.nginx"
-	integrationVersion = "1.1.0"
+	integrationVersion = "1.3.0"
 
 	entityRemoteType = "server"
 
@@ -33,7 +33,6 @@ const (
 	httpDefaultPort  = `80`
 	httpsDefaultPort = `443`
 
-	apiv4          = "/api/4"
 	httpStubStatus = "ngx_http_stub_status_module"
 	httpStatus     = "ngx_http_status_module"
 	httpApiStatus  = "ngx_http_api_module"

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -14,9 +14,12 @@ import (
 
 type argumentList struct {
 	sdk_args.DefaultArgumentList
-	StatusURL        string `default:"http://127.0.0.1/status" help:"NGINX status URL."`
-	ConfigPath       string `default:"/etc/nginx/nginx.conf" help:"NGINX configuration file."`
-	RemoteMonitoring bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
+	StatusURL         string `default:"http://127.0.0.1/status" help:"NGINX status URL. If you are using ngx_http_api_module be sure to include the full path ending with the API version number"`
+	ConfigPath        string `default:"/etc/nginx/nginx.conf" help:"NGINX configuration file."`
+	RemoteMonitoring  bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
+	ConnectionTimeout int    `default:"1" help:"OHI connection to Nginx timeout in seconds"`
+	StatusModule      string `default:"ngx_http_stub_status_module" help:"Name of Nginx status module. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module"`
+	Endpoints         string `default:"/nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync" help:"Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints"`
 }
 
 const (
@@ -29,6 +32,11 @@ const (
 	httpProtocol     = `http`
 	httpDefaultPort  = `80`
 	httpsDefaultPort = `443`
+
+	apiv4          = "/api/4"
+	httpStubStatus = "ngx_http_stub_status_module"
+	httpStatus     = "ngx_http_status_module"
+	httpApiStatus  = "ngx_http_api_module"
 )
 
 var (

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
+	"net/url"
+	"os"
+
 	sdk_args "github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/pkg/errors"
-	"net/url"
-	"os"
 )
 
 type argumentList struct {
@@ -18,7 +19,7 @@ type argumentList struct {
 	ConfigPath        string `default:"/etc/nginx/nginx.conf" help:"NGINX configuration file."`
 	RemoteMonitoring  bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
 	ConnectionTimeout int    `default:"1" help:"OHI connection to Nginx timeout in seconds"`
-	StatusModule      string `default:"ngx_http_stub_status_module" help:"Name of Nginx status module. ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module"`
+	StatusModule      string `default:"discover" help:"Name of Nginx status module. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module"`
 	Endpoints         string `default:"/nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync" help:"Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints"`
 }
 
@@ -33,9 +34,10 @@ const (
 	httpDefaultPort  = `80`
 	httpsDefaultPort = `443`
 
+	discoverStatus = "discover"
 	httpStubStatus = "ngx_http_stub_status_module"
 	httpStatus     = "ngx_http_status_module"
-	httpApiStatus  = "ngx_http_api_module"
+	httpAPIStatus  = "ngx_http_api_module"
 )
 
 var (

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.9 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-nginx
 COPY . .

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.12 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-nginx
 COPY . .

--- a/tests/integration/json-schema-files/nginx-schema-inventory.json
+++ b/tests/integration/json-schema-files/nginx-schema-inventory.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.1.0$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema-metrics.json
+++ b/tests/integration/json-schema-files/nginx-schema-metrics.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.1.0$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema.json
+++ b/tests/integration/json-schema-files/nginx-schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.1.0$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/nginx_test.go
+++ b/tests/integration/nginx_test.go
@@ -111,7 +111,7 @@ func TestNGINXIntegrationInvalidStatusURL(t *testing.T) {
 
 	stdout, stderr, err := runIntegration(t, "STATUS_URL=http://localhost/", fmt.Sprintf("NRIA_CACHE_PATH=%v", testName), "VERBOSE=true")
 
-	expectedErrorMessage := " connect: connection refused"
+	expectedErrorMessage := "connection refused"
 
 	errMatch, _ := regexp.MatchString(expectedErrorMessage, stderr)
 	assert.Error(t, err, "Expected error")

--- a/vendor/github.com/jeremywohl/flatten/LICENSE
+++ b/vendor/github.com/jeremywohl/flatten/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Jeremy Wohl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jeremywohl/flatten/README.md
+++ b/vendor/github.com/jeremywohl/flatten/README.md
@@ -1,0 +1,54 @@
+flatten
+=======
+
+[![GoDoc](https://godoc.org/github.com/jeremywohl/flatten?status.png)](https://godoc.org/github.com/jeremywohl/flatten)
+[![Build Status](https://travis-ci.org/jeremywohl/flatten.svg?branch=master)](https://travis-ci.org/jeremywohl/flatten)
+
+Flatten makes flat, one-dimensional maps from arbitrarily nested ones.
+
+It turns map keys into compound
+names, in four styles: dotted (`a.b.1.c`), path-like (`a/b/1/c`), Rails (`a[b][1][c]`), or with underscores (`a_b_1_c`).  It takes input as either JSON strings or
+Go structures.  It knows how to traverse these JSON types: objects/maps, arrays and scalars.
+
+You can flatten JSON strings.
+
+```go
+nested := `{
+  "one": {
+    "two": [
+      "2a",
+      "2b"
+    ]
+  },
+  "side": "value"
+}`
+
+flat, err := flatten.FlattenString(nested, "", flatten.DotStyle)
+
+// output: `{ "one.two.0": "2a", "one.two.1": "2b", "side": "value" }`
+```
+
+Or Go maps directly.
+
+```go
+nested := map[string]interface{}{
+   "a": "b",
+   "c": map[string]interface{}{
+       "d": "e",
+       "f": "g",
+   },
+   "z": 1.4567,
+}
+
+flat, err := flatten.Flatten(nested, "", flatten.RailsStyle)
+
+// output:
+// map[string]interface{}{
+//  "a":    "b",
+//  "c[d]": "e",
+//  "c[f]": "g",
+//  "z":    1.4567,
+// }
+```
+
+See [godoc](https://godoc.org/github.com/jeremywohl/flatten) for API.

--- a/vendor/github.com/jeremywohl/flatten/TODO
+++ b/vendor/github.com/jeremywohl/flatten/TODO
@@ -1,0 +1,4 @@
+test: all Go scalar types
+todo: initial list vs map
+todo: fail properly with alternate types
+todo: support structs and pointers?

--- a/vendor/github.com/jeremywohl/flatten/flatten.go
+++ b/vendor/github.com/jeremywohl/flatten/flatten.go
@@ -1,0 +1,162 @@
+// Flatten makes flat, one-dimensional maps from arbitrarily nested ones.
+//
+// It turns map keys into compound
+// names, in four styles: dotted (`a.b.1.c`), path-like (`a/b/1/c`), Rails (`a[b][1][c]`), or with underscores (`a_b_1_c`).  It takes input as either JSON strings or
+// Go structures.  It knows how to traverse these JSON types: objects/maps, arrays and scalars.
+//
+// You can flatten JSON strings.
+//
+//	nested := `{
+//	  "one": {
+//	    "two": [
+//	      "2a",
+//	      "2b"
+//	    ]
+//	  },
+//	  "side": "value"
+//	}`
+//
+//	flat, err := flatten.FlattenString(nested, "", flatten.DotStyle)
+//
+//	// output: `{ "one.two.0": "2a", "one.two.1": "2b", "side": "value" }`
+//
+// Or Go maps directly.
+//
+//	nested := map[string]interface{}{
+//		"a": "b",
+//		"c": map[string]interface{}{
+//			"d": "e",
+//			"f": "g",
+//		},
+//		"z": 1.4567,
+//	}
+//
+//	flat, err := flatten.Flatten(nested, "", flatten.RailsStyle)
+//
+//	// output:
+//	// map[string]interface{}{
+//	//	"a":    "b",
+//	//	"c[d]": "e",
+//	//	"c[f]": "g",
+//	//	"z":    1.4567,
+//	// }
+//
+package flatten
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+)
+
+// The presentation style of keys.
+type SeparatorStyle int
+
+const (
+	_ SeparatorStyle = iota
+
+	// Separate nested key components with dots, e.g. "a.b.1.c.d"
+	DotStyle
+
+	// Separate with path-like slashes, e.g. a/b/1/c/d
+	PathStyle
+
+	// Separate ala Rails, e.g. "a[b][c][1][d]"
+	RailsStyle
+
+	// Separate with underscores, e.g. "a_b_1_c_d"
+	UnderscoreStyle
+)
+
+// Nested input must be a map or slice
+var NotValidInputError = errors.New("Not a valid input: map or slice")
+
+// Flatten generates a flat map from a nested one.  The original may include values of type map, slice and scalar,
+// but not struct.  Keys in the flat map will be a compound of descending map keys and slice iterations.
+// The presentation of keys is set by style.  A prefix is joined to each key.
+func Flatten(nested map[string]interface{}, prefix string, style SeparatorStyle) (map[string]interface{}, error) {
+	flatmap := make(map[string]interface{})
+
+	err := flatten(true, flatmap, nested, prefix, style)
+	if err != nil {
+		return nil, err
+	}
+
+	return flatmap, nil
+}
+
+// FlattenString generates a flat JSON map from a nested one.  Keys in the flat map will be a compound of
+// descending map keys and slice iterations.  The presentation of keys is set by style.  A prefix is joined
+// to each key.
+func FlattenString(nestedstr, prefix string, style SeparatorStyle) (string, error) {
+	var nested map[string]interface{}
+	err := json.Unmarshal([]byte(nestedstr), &nested)
+	if err != nil {
+		return "", err
+	}
+
+	flatmap, err := Flatten(nested, prefix, style)
+	if err != nil {
+		return "", err
+	}
+
+	flatb, err := json.Marshal(&flatmap)
+	if err != nil {
+		return "", err
+	}
+
+	return string(flatb), nil
+}
+
+func flatten(top bool, flatMap map[string]interface{}, nested interface{}, prefix string, style SeparatorStyle) error {
+	assign := func(newKey string, v interface{}) error {
+		switch v.(type) {
+		case map[string]interface{}, []interface{}:
+			if err := flatten(false, flatMap, v, newKey, style); err != nil {
+				return err
+			}
+		default:
+			flatMap[newKey] = v
+		}
+
+		return nil
+	}
+
+	switch nested.(type) {
+	case map[string]interface{}:
+		for k, v := range nested.(map[string]interface{}) {
+			newKey := enkey(top, prefix, k, style)
+			assign(newKey, v)
+		}
+	case []interface{}:
+		for i, v := range nested.([]interface{}) {
+			newKey := enkey(top, prefix, strconv.Itoa(i), style)
+			assign(newKey, v)
+		}
+	default:
+		return NotValidInputError
+	}
+
+	return nil
+}
+
+func enkey(top bool, prefix, subkey string, style SeparatorStyle) string {
+	key := prefix
+
+	if top {
+		key += subkey
+	} else {
+		switch style {
+		case DotStyle:
+			key += "." + subkey
+		case PathStyle:
+			key += "/" + subkey
+		case RailsStyle:
+			key += "[" + subkey + "]"
+		case UnderscoreStyle:
+			key += "_" + subkey
+		}
+	}
+
+	return key
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -13,6 +13,12 @@
 			"revisionTime": "2018-08-30T19:11:22Z"
 		},
 		{
+			"checksumSHA1": "peajuCOZXpi7Pwivo5UZmyevkiM=",
+			"path": "github.com/jeremywohl/flatten",
+			"revision": "588fe0d4c603f5dc8b3854ff3f7f16e570618ef7",
+			"revisionTime": "2018-09-23T03:50:01Z"
+		},
+		{
 			"checksumSHA1": "ZfId5ZYn7jmL0xTxooHcxrLlXoA=",
 			"path": "github.com/newrelic/infra-integrations-sdk/args",
 			"revision": "1d56d083ff58c63604755586fe1a65036a064de7",


### PR DESCRIPTION
#### Description of the changes

- Support for `ngx_http_api_module`.
- New configuration options:
    - `connection_timeout`: timeout (in seconds) for the connection from the integration to Nginx
    - `status_module` (default: `discover`). Accepted values:
        * `ngx_http_stub_status_module`
        * `ngx_http_status_module`
        * `ngx_http_api_module`
        * `discover` to automatically choose between `ngx_http_stub_status_module` or `ngx_http_status_module` (added for backwards-compatibility)
    - `endpoints`: if `status_module` is `ngx_http_api_module`, comma separated list, NON PARAMETERIZED, Endpoints   

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
