### PR TITLE
Cleaning up tab character, aligning indentation

### DIFF
--- a/nginx-config.yml.sample
+++ b/nginx-config.yml.sample
@@ -6,12 +6,11 @@ instances:
       arguments:
           # If you're using ngx_http_api_module be certain to use the full path up to and including the version number
           status_url: http://127.0.0.1/status
-	      # Name of Nginx status module OHI is to query against. discovery | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-	      status_module: discovery
-
-	      # ngx_http_api_module ONLY
+    
           # Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints
           # endpoints: /nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync
+          # Name of Nginx status module OHI is to query against. discovery | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
+          status_module: discovery
 
           # New users should leave this property as `true`, to identify the
           # monitored entities as `remote`. Setting this property to `false` (the


### PR DESCRIPTION
#### Description of the changes

Tab character causes a YAML syntax error when the Infrastructure agent tries to parse the config.  Aligning indentation, as there isn't any code change I could see that would try to parse an attribute under `status_url`.  Rearranged comment lines.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
