### PR TITLE
Added default case for status_module when getting metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ go.sum
 
 # Vim session
 Session.vim
+
+.idea

--- a/nginx-config.yml.sample
+++ b/nginx-config.yml.sample
@@ -9,8 +9,8 @@ instances:
     
           # Comma separated list of ngx_http_api_module, NON PARAMETERIZED, Endpoints
           # endpoints: /nginx,/processes,/connections,/ssl,/slabs,/http,/http/requests,/http/server_zones,/http/caches,/http/upstreams,/http/keyvals,/stream,/stream/server_zones,/stream/upstreams,/stream/keyvals,/stream/zone_sync
-          # Name of Nginx status module OHI is to query against. discovery | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
-          status_module: discovery
+          # Name of Nginx status module OHI is to query against. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
+          status_module: discover
 
           # New users should leave this property as `true`, to identify the
           # monitored entities as `remote`. Setting this property to `false` (the


### PR DESCRIPTION
#### Description of the changes

Added default case for ``status_module`` because the flag has ``discover`` as a default setting, and therefore this should be treated as a default. This is in response to https://newrelic.atlassian.net/secure/RapidBoard.jspa?rapidView=594&modal=detail&selectedIssue=IHOST-2447 where a typo in configuration (discover**y** instead of discover, led to metrics not being collected). 

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
