### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.4.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-nginx to nri-nginx in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 1.3.1 (2019-09-19)
 - Fixed automatic discovery of the `status_module`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.9 as builder
-RUN go get -d github.com/newrelic/nri-nginx/... && \
-    cd /go/src/github.com/newrelic/nri-nginx && \
+COPY . /go/src/github.com/newrelic/nri-nginx/
+RUN cd /go/src/github.com/newrelic/nri-nginx && \
     make && \
-    strip ./bin/nr-nginx
+    strip ./bin/nri-nginx
 
 FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
-COPY --from=builder /go/src/github.com/newrelic/nri-nginx/bin/nr-nginx /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nr-nginx
+COPY --from=builder /go/src/github.com/newrelic/nri-nginx/bin/nri-nginx /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-nginx
 COPY --from=builder /go/src/github.com/newrelic/nri-nginx/nginx-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/definition.yml
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export PATH := $(PATH):$(GOPATH)/bin
 
 INTEGRATION     := nginx
-BINARY_NAME      = nr-$(INTEGRATION)
+BINARY_NAME      = nri-$(INTEGRATION)
 SRC_DIR          = ./src/
 VALIDATE_DEPS    = golang.org/x/lint/golint
 TEST_DEPS        = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Additions to the `nginx-config.yaml` file:
 ## Installation
 * download an archive file for the NGINX Integration
 * extract `nginx-definition.yml` and `/bin` directory into `/var/db/newrelic-infra/newrelic-integrations`
-* add execute permissions for the binary file `nr-nginx` (if required)
+* add execute permissions for the binary file `nri-nginx` (if required)
 * extract `nginx-config.yml.sample` into `/etc/newrelic-infra/integrations.d`
 
 ## Usage
@@ -42,13 +42,13 @@ Assuming that you have source code you can build and run the NGINX Integration l
 ```bash
 $ make
 ```
-* The command above will execute tests for the NGINX Integration and build an executable file called `nr-nginx` in `bin` directory.
+* The command above will execute tests for the NGINX Integration and build an executable file called `nri-nginx` in `bin` directory.
 ```bash
-$ ./bin/nr-nginx
+$ ./bin/nri-nginx
 ```
-* If you want to know more about usage of `./nr-nginx` check
+* If you want to know more about usage of `./nri-nginx` check
 ```bash
-$ ./bin/nr-nginx -help
+$ ./bin/nri-nginx -help
 ```
 
 For managing external dependencies [govendor tool](https://github.com/kardianos/govendor) is used. It is required to lock all external dependencies to specific version (if possible) into vendor directory.

--- a/nginx-definition.yml
+++ b/nginx-definition.yml
@@ -6,13 +6,13 @@ os: linux
 commands:
     metrics:
         command:
-          - ./bin/nr-nginx
+          - ./bin/nri-nginx
           - -metrics
         interval: 30
 
     inventory:
         command:
-          - ./bin/nr-nginx
+          - ./bin/nri-nginx
           - -inventory
         prefix: config/nginx
         interval: 60

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -25,7 +25,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.nginx"
-	integrationVersion = "1.3.0"
+	integrationVersion = "1.4.0"
 
 	entityRemoteType = "server"
 

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     - ./nginx/nginx.conf:/etc/nginx/nginx.conf
 
   nri-nginx:
+    container_name: integration_nri-nginx_1
     build:
       context: ../../
       dockerfile: tests/integration/Dockerfile

--- a/tests/integration/json-schema-files/nginx-schema-inventory.json
+++ b/tests/integration/json-schema-files/nginx-schema-inventory.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.3.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema-metrics.json
+++ b/tests/integration/json-schema-files/nginx-schema-metrics.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.3.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema.json
+++ b/tests/integration/json-schema-files/nginx-schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.3.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/nginx_test.go
+++ b/tests/integration/nginx_test.go
@@ -21,7 +21,7 @@ var (
 
 	defaultContainer = "integration_nri-nginx_1"
 
-	defaultBinPath   = "/nr-nginx"
+	defaultBinPath   = "/nri-nginx"
 	defaultStatusURL = "http://nginx:8080/status"
 
 	// cli flags


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-nginx to nri-nginx in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.