### PR TITLE
Make integration tests version independent.

### DIFF
--- a/tests/integration/json-schema-files/nginx-schema-inventory.json
+++ b/tests/integration/json-schema-files/nginx-schema-inventory.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema-metrics.json
+++ b/tests/integration/json-schema-files/nginx-schema-metrics.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/nginx-schema.json
+++ b/tests/integration/json-schema-files/nginx-schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
       "type": "string"
     },
     "data": {


### PR DESCRIPTION
Replaced concrete version with regex so we don't have to update this of every release.