### PR TITLE
Parsing http api status module metric names correctly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0 (2019-01-28)
+## Fixed
+- Nginx Plus metrics were not being renamed like Nginx standard metrics
+## Changed
+- Major version change as the fix above breaks compatibility by renaming metrics
+
 ## 1.5.1 (2019-12-10)
 ## Fixed
 - Integration version reporting

--- a/src/nginx.go
+++ b/src/nginx.go
@@ -26,7 +26,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.nginx"
-	integrationVersion = "1.5.1"
+	integrationVersion = "2.0.0"
 
 	entityRemoteType = "server"
 


### PR DESCRIPTION
When using NGINX Plus with the HTTP API Status module, some metric names weren't being renamed so that the NGINX dashboard can be used. This PR is in reference to https://newrelic.atlassian.net/browse/GTSE-689

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
