### PR TITLE
Add REMOTE_MONITORING flag to k8s config sample file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ go.sum
 Session.vim
 
 .idea
+.vscode

--- a/nginx-config.yml.k8s_sample
+++ b/nginx-config.yml.k8s_sample
@@ -18,3 +18,4 @@
           # Name of Nginx status module OHI is to query against. discover | ngx_http_stub_status_module | ngx_http_status_module | ngx_http_api_module
           STATUS_MODULE: discover
           METRICS: 1
+          REMOTE_MONITORING: 1


### PR DESCRIPTION
#### Description of the changes

REMOTE_MONITORING was not set in k8s config file what made that the integration was reusing the cache file for all the instances with the same port (the port was the only attribute used as a key for the cache data). And this was causing wired metrics reports like negative rate values metrics.

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
