### PR TITLE
fix: Discover Nginx Plus Api metrics

### DIFF
--- a/src/nginx.go
+++ b/src/nginx.go
@@ -42,6 +42,8 @@ const (
 	httpStubStatus = "ngx_http_stub_status_module"
 	httpStatus     = "ngx_http_status_module"
 	httpAPIStatus  = "ngx_http_api_module"
+
+	nginxPlusApiRootNginxEndpoint = `"nginx"`
 )
 
 var (


### PR DESCRIPTION
When the status_module is set to discover, now it will also get metrics in NGINX PLUS with ngx_http_api_module that became the only status option in NGINX PLUS  >= 1.13.10.  [http://nginx.org/en/docs/http/ngx_http_api_module.html]http://nginx.org/en/docs/http/ngx_http_api_module.html