### PR TITLE
NR-58191 Handle EOF error properly when parsing nginx.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.5 (2022-10-18)
+## Fixed
+- Handle properly the error while parsing the `nginx.conf` file and ignoring the comments #96.
+
 ## 3.2.4 (2022-06-21)
 ### Changed
 - Bump dependencies

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/newrelic/infra-integrations-sdk/data/inventory"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/newrelic/infra-integrations-sdk/data/inventory"
+	"github.com/pkg/errors"
 )
 
 var errMissingClosingBracket = fmt.Errorf("missing closing bracket")
@@ -22,7 +24,7 @@ func populateInventory(reader *bufio.Reader, i *inventory.Inventory) error {
 		r, _, err := reader.ReadRune()
 		if err != nil {
 			// If we reached the end of the file no error should be returned.
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 
@@ -78,7 +80,7 @@ func populateInventory(reader *bufio.Reader, i *inventory.Inventory) error {
 			for r != '\n' {
 				r, _, err = reader.ReadRune()
 				if err != nil {
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						return nil
 					}
 					return fmt.Errorf("ignoring comment at line %d: %w", lineNo, err)

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -76,7 +76,13 @@ func populateInventory(reader *bufio.Reader, i *inventory.Inventory) error {
 		case '#':
 			// ignore comments
 			for r != '\n' {
-				r, _, _ = reader.ReadRune()
+				r, _, err = reader.ReadRune()
+				if err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return fmt.Errorf("ignoring comment at line %d: %w", lineNo, err)
+				}
 			}
 		case '\t', ' ':
 			if curValue == "" {

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -67,10 +67,14 @@ func populateInventory(reader *bufio.Reader, i *inventory.Inventory) error {
 					lineNo++
 				}
 				r, _, err = reader.ReadRune()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return nil
+					}
+					return fmt.Errorf("parsing line %d: %w", lineNo, err)
+				}
 			}
-			if err != nil {
-				continue // Break to outer loop so we can handle errors/EOF
-			}
+
 			err = reader.UnreadRune()
 			if err != nil {
 				return fmt.Errorf("parsing line %d: %w", lineNo, err)
@@ -83,7 +87,7 @@ func populateInventory(reader *bufio.Reader, i *inventory.Inventory) error {
 					if errors.Is(err, io.EOF) {
 						return nil
 					}
-					return fmt.Errorf("ignoring comment at line %d: %w", lineNo, err)
+					return fmt.Errorf("parsing line %d: %w", lineNo, err)
 				}
 			}
 		case '\t', ' ':

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -337,7 +337,8 @@ func getDiscoveredMetricsData(sample *metric.Set) error {
 	var metricsDefinition map[string][]interface{}
 
 	if resp.Header.Get("content-type") == "application/json" {
-		bodyBytes, err := io.ReadAll(resp.Body)
+		var bodyBytes []byte
+		bodyBytes, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+
 	"net/http"
 	"regexp"
 	"strconv"
@@ -17,6 +17,7 @@ import (
 	"github.com/jeremywohl/flatten"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/pkg/errors"
 )
 
 var metricsStandardDefinition = map[string][]interface{}{
@@ -96,7 +97,7 @@ func getStandardMetrics(reader *bufio.Reader) (map[string]interface{}, error) {
 
 		match := re.FindStringSubmatch(line)
 		if match == nil {
-			return nil, fmt.Errorf("Line %d of status doesn't match", lineNo)
+			return nil, errors.Errorf("line %d of status doesn't match", lineNo)
 		}
 
 		for i, name := range re.SubexpNames() {
@@ -314,7 +315,7 @@ func getStatus(path string) (resp *http.Response, err error) {
 		return
 	}
 	if resp.StatusCode != http.StatusOK {
-		return resp, fmt.Errorf("failed to get stats from %s. Server returned code %d (%s). Expecting 200", args.StatusURL+path, resp.StatusCode, resp.Status)
+		return resp, errors.Errorf("failed to get stats from %s. Server returned code %d (%s). Expecting 200", args.StatusURL+path, resp.StatusCode, resp.Status)
 	}
 	return
 }
@@ -328,7 +329,7 @@ func getDiscoveredMetricsData(sample *metric.Set) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to get stats from nginx. Server returned code %d (%s). Expecting 200",
+		return errors.Errorf("failed to get stats from nginx. Server returned code %d (%s). Expecting 200",
 			resp.StatusCode, resp.Status)
 	}
 	defer resp.Body.Close()
@@ -336,7 +337,7 @@ func getDiscoveredMetricsData(sample *metric.Set) error {
 	var metricsDefinition map[string][]interface{}
 
 	if resp.Header.Get("content-type") == "application/json" {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -180,7 +180,7 @@ func Test_getMetricsData(t *testing.T) {
 		{
 			name:      "testBadNginxStandardStatus",
 			response:  testBadNginxStandardStatus,
-			expectErr: errors.New("Line 2 of status doesn't match"),
+			expectErr: errors.New("line 2 of status doesn't match"),
 		},
 		{
 			name:                      "testNginxPlusStatus",

--- a/src/testdata/nginx_with_comment.conf
+++ b/src/testdata/nginx_with_comment.conf
@@ -1,0 +1,44 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+            listen 8080;
+    		server_name localhost;
+
+            location /status {
+                stub_status on;
+                access_log off;
+                allow all;
+            }
+    }
+
+    include /etc/nginx/conf.d/*.conf;
+}
+# End comment, don't add a line break. Watch out with IDEs adding it automatically!

--- a/tests/integration/jsonschema/jsonschema.go
+++ b/tests/integration/jsonschema/jsonschema.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -24,7 +25,7 @@ func Validate(fileName string, input string) error {
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		return fmt.Errorf("Error loading JSON schema, error: %v", err)
+		return fmt.Errorf("loading JSON schema, error: %w", err)
 	}
 
 	if result.Valid() {
@@ -35,7 +36,7 @@ func Validate(fileName string, input string) error {
 		fmt.Printf("\t- %s\n", desc)
 	}
 	fmt.Printf("\n")
-	return fmt.Errorf("The output of the integration doesn't have expected JSON format")
+	return errors.New("the output of the integration doesn't have expected JSON format")
 }
 
 // ValidationField is a struct used in JSON schema


### PR DESCRIPTION
We had an issue while parsing the `nginx.conf` file if the last line was a comment. In order to fix this we need to handle properly the `EOF` error while ignoring the comments otherwise we are kept in an infinite loop. 

Note: Fixed as well some golangci-lint errors on the way.