### PR TITLE
fix: upgrade go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+
+### security
+- update go to v1.25.9
 ## v3.7.0 - 2026-03-25
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-nginx
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/jeremywohl/flatten v1.0.1

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-bookworm as builder
+FROM golang:1.25.9-bookworm as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-nginx
 COPY . .


### PR DESCRIPTION
## Summary
- Update Go to v1.25.9
- Update `tests/integration/Dockerfile` to use `golang:1.25.9-bookworm`
- Run `go mod tidy` to update dependencies
- Update CHANGELOG.md with security entry

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)